### PR TITLE
add SHANOIR_INSTANCE_NAME/SHANOIR_INSTANCE_COLOR

### DIFF
--- a/.env
+++ b/.env
@@ -86,20 +86,22 @@ SHANOIR_KEYCLOAK_PASSWORD=&a1A&a1A
 SHANOIR_MIGRATION=auto
 
 
-# Override css colors
+
+# Name of this shanoir instance
 #
-# If defined, this variables overrides the value of css colors.
+# If defined, the name is displayed in the UI at the top of the side-bar.
 #
-# eg:
-#	SHANOIR_COLOR="a:#001122 b:#aabbcc"
-#   will override the followind CSS values:
-#	--color-a: #001122;
-#	--color-b: #aabbcc;
+#   eg: SHANOIR_INSTANCE_NAME=QUALIF
 #
-# Use it if you have multiple instances of shanoir and want to have different
-# themes to dinstinguish them easily.
+SHANOIR_INSTANCE_NAME=
+
+# Custom color for this shanoir instance
+# 
+# If defined, this variable overrides the background color of the instance name
+# and the color of the user icon in the side bar.
+# 
+# This must be a valid HTML color (predifined name or #RGB value)
 #
-# default theme:
-#SHANOIR_COLORS=a:#5f0f4e a-light:#6C1C5B b:#675682 b-light:#E3E0E8 b-light2:#827498
-# reddish theme:
-#SHANOIR_COLORS=a:#a00000 a-light:#b00000 b:#882e2e b-light:#edd0d0 b-light2:#ad5d5d
+#   eg: SHANOIR_INSTANCE_COLOR=teal
+#
+SHANOIR_INSTANCE_COLOR=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,7 +297,8 @@ services:
       - SHANOIR_URL_HOST
       - SHANOIR_URL_SCHEME
       - SHANOIR_X_FORWARDED
-      - SHANOIR_COLORS
+      - SHANOIR_INSTANCE_NAME
+      - SHANOIR_INSTANCE_COLOR
     volumes:
       - "logs:/var/log/nginx"
       - certificate-share-data:/opt/ssl:ro

--- a/docker-compose/nginx/entrypoint
+++ b/docker-compose/nginx/entrypoint
@@ -28,25 +28,24 @@ dst="/etc/nginx/server.conf"
 sed "s/SHANOIR_URL_HOST/$SHANOIR_URL_HOST/g" "$src" > "$dst"
 
 
-# change theme colors
-override_colors()
+configure_instance()
 {
-	local spec
-	for spec in $SHANOIR_COLORS ; do
-		if [[ "$spec" =~ ^([A-Za-z0-9-]+):(#[0-9A-Fa-f]{3,6})$ ]] ; then
-			local name="${BASH_REMATCH[1]}"
-			local value="${BASH_REMATCH[2]}"
+	local user_color="${SHANOIR_INSTANCE_COLOR:-#813371}"
 
-			sed -i "s/^\( *--color-$name *:\).*/\1 $value;/" /etc/nginx/html/assets/css/common.css /etc/nginx/html/styles.*.css
-		else
-			error "malformatted color spec in SHANOIR_COLORS: '$spec'  (expected: name:#xxxxxx)"
-		fi
+	local instance_color="transparent"
+	if [ -n "$SHANOIR_INSTANCE_NAME" ] ; then
+		instance_color="$user_color"
+	fi
 
-	done
+	sed -i "s\"SHANOIR_INSTANCE_NAME\"$SHANOIR_INSTANCE_NAME\"g
+		s/SHANOIR_INSTANCE_COLOR/$instance_color/g
+		s/SHANOIR_USER_COLOR/$user_color/g
+		" /etc/nginx/html/assets/css/common.css /etc/nginx/html/styles.*.css
 }
 
-optional SHANOIR_COLORS
-override_colors
+optional SHANOIR_INSTANCE_COLOR
+optional SHANOIR_INSTANCE_NAME
+configure_instance
 
 abort_if_error
 

--- a/shanoir-ng-front/src/assets/css/common.css
+++ b/shanoir-ng-front/src/assets/css/common.css
@@ -26,14 +26,9 @@
     --shadow-height: 15px;
     --shadow-color: rgba(0,0,0,0.3);
     
-    /* --instance-name: "QUALIF";
-    --instance-color: teal;
-    --user-color: teal; */
-
-    --instance-name: ;
-    --instance-color: transparent;
-    --user-color: #813371;
-
+    --instance-name: "SHANOIR_INSTANCE_NAME";
+    --instance-color: SHANOIR_INSTANCE_COLOR;
+    --user-color:     SHANOIR_USER_COLOR;
 }
 
 body { margin: 0; background-color: var(--very-light-grey); }

--- a/utils/entrypoint_common
+++ b/utils/entrypoint_common
@@ -66,7 +66,8 @@ require()
             SHANOIR_CERTIFICATE)    match "$name" '^(auto|manual)$'                     ;;
             SHANOIR_MIGRATION)      match "$name" '^(auto|init|never|import|export)$'   ;;
 	    SHANOIR_X_FORWARDED)    match "$name" '^(generate|trust)$'			;;
-            SHANOIR_COLORS)         match "$name" '^[A-Za-z0-9-]+:#[0-9a-fA-F]{6}( +[A-Za-z0-9-]+:#[0-9a-fA-F]{6})*$' ;;
+	    SHANOIR_INSTANCE_NAME)  match "$name" '^[^"\\]*$'				;;
+	    SHANOIR_INSTANCE_COLOR) match "$name" '^([A-Za-z]*|#[0-9a-fA-F]{3,6})$'	;;
 
             SHANOIR_ADMIN_EMAIL)    ;;
             SHANOIR_ADMIN_NAME)     ;;


### PR DESCRIPTION
(replaces SHANOIR_COLORS)

Suggestion: how about
- showing the instance name and colors in the keycloak login page
- showing the instance name in the html `<title>`